### PR TITLE
 Enables cinder-driver to write host IPs to volume ACL to restrict access

### DIFF
--- a/cinder/volume/drivers/lightos.py
+++ b/cinder/volume/drivers/lightos.py
@@ -77,7 +77,15 @@ lightos_opts = [
     cfg.IntOpt('lightos_api_service_timeout',
                default=30,
                help='The default amount of time (in seconds) to wait for'
-               ' an API endpoint response.')
+               ' an API endpoint response.'),
+    cfg.BoolOpt('lightos_use_ipacl',
+               default=True,
+               help='IPACL work in conjunction with the standard NVME ACL.'
+                    'A host must be in both the IPACL and the ACL of a volume to access that volume.'
+                    'Cinder always sets the volume`s ACL. If lightos_use_ipacl is set to True,' 
+                    'Cinder will also add the host`s IP addresses to a volume IPACL.' 
+                    'If set to False, any IP address may access the volume. The default is True.'),
+               
 ]
 
 CONF = cfg.CONF
@@ -151,6 +159,9 @@ class LightOSConnection(object):
                                   'compression': kwargs.get('compression'),
                                   'acl': {
                                       'values': kwargs.get('acl'),
+                                  },
+                                  'IPAcl': {
+                                      'values': kwargs.get('ip_acl'),
                                   },
                                   'sourceSnapshotUUID': kwargs.get(
                                       'src_snapshot_uuid'),
@@ -600,6 +611,7 @@ class LightOSVolumeDriver(driver.VolumeDriver):
                                    src_snapshot_lightos_name=None):
         """Create a new LightOS volume for this openstack volume."""
         (compression, num_replicas, _) = self._get_volume_specs(os_volume)
+        vol_ipAcl = ['ALLOW_NONE'] if self.use_ip_acl() else ['ALLOW_ANY']
         return self.cluster.send_cmd(
             cmd='create_volume',
             project_name=project_name,
@@ -609,7 +621,8 @@ class LightOSVolumeDriver(driver.VolumeDriver):
             n_replicas=num_replicas,
             compression=compression,
             src_snapshot_name=src_snapshot_lightos_name,
-            acl=['ALLOW_NONE']
+            acl=['ALLOW_NONE'],
+            ip_acl=vol_ipAcl
         )
 
     def _get_lightos_uuid(self, project_name, volume):
@@ -1036,7 +1049,7 @@ class LightOSVolumeDriver(driver.VolumeDriver):
 
         return server_properties
 
-    def set_volume_acl(self, project_name, lightos_uuid, acl, ip_acl,etag):
+    def set_volume_acl(self, project_name, lightos_uuid, acl, ip_acl, etag):
         return self.cluster.send_cmd(
             cmd='update_volume',
             project_name=project_name,
@@ -1047,7 +1060,10 @@ class LightOSVolumeDriver(driver.VolumeDriver):
             etag=etag
         )
 
-    def __add_volume_acl(self, project_name, lightos_volname, acl_to_add,host_ips):
+    def use_ip_acl(self):
+        return self.configuration.lightos_use_ipacl
+
+    def __add_volume_acl(self, project_name, lightos_volname, acl_to_add, host_ips):
         (status, data) = self._get_lightos_volume(project_name,
                                                   self.logical_op_timeout,
                                                   vol_name=lightos_volname)
@@ -1060,14 +1076,15 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         if not lightos_uuid:
             LOG.warning('Got LightOS volume without UUID?! data: %s', data)
             return False
-
+        
         acl = data.get('acl')
         if not acl:
             LOG.warning('Got LightOS volume without ACL?! data: %s', data)
             return False
 
+        
         ip_acl= data.get('IPAcl')         
-        if not ip_acl:
+        if self.use_ip_acl() and not ip_acl:
            LOG.warning('Got LightOS volume without IP ACL?! data: %s', data)
            return False
 
@@ -1079,26 +1096,24 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         if 'ALLOW_NONE' in acl:
             acl.remove('ALLOW_NONE')
         if acl_to_add not in acl:
-            acl.append(acl_to_add)
+           acl.append(acl_to_add)
 
-        if 'ALLOW_ANY' in ip_acl:
-            ip_acl.remove('ALLOW_ANY')
-        
-        if 'ALLOW_NONE' in ip_acl:
-            ip_acl.remove('ALLOW_NONE')
-        
-        ip_acl=set(ip_acl).union(set(host_ips))
-        ip_acl= list(ip_acl)
-        
+        ip_acl=[]    
+        if self.use_ip_acl():
+           ip_acl=host_ips
+        else:
+           ip_acl.append('ALLOW_ANY')
+                
         return self.set_volume_acl(
             project_name,
             lightos_uuid,
-            acl,ip_acl,
+            acl, 
+            ip_acl,
             etag=data.get(
                 'ETag',
                 ''))
 
-    def add_volume_acl(self, project_name, volume, acl_to_add,host_ips):
+    def add_volume_acl(self, project_name, volume, acl_to_add, host_ips):
         LOG.debug(
             'add_volume_acl got volume %s project %s acl %s',
             volume,
@@ -1109,13 +1124,15 @@ class LightOSVolumeDriver(driver.VolumeDriver):
             self.__add_volume_acl,
             project_name,
             lightos_volname,
-            acl_to_add,host_ips)
+            acl_to_add,
+            host_ips)
 
     def __remove_volume_acl(
             self,
             project_name,
             lightos_volname,
-            acl_to_remove,host_ips):
+            acl_to_remove,
+            host_ips):
         (status, data) = self._get_lightos_volume(project_name,
                                                   self.logical_op_timeout,
                                                   vol_name=lightos_volname)
@@ -1157,12 +1174,12 @@ class LightOSVolumeDriver(driver.VolumeDriver):
             acl.append('ALLOW_NONE')
 
         ip_acl = data.get('IPAcl')
-        if not ip_acl:
-            LOG.warning('Got LightOS volume without IP ACL?! data: %s', data)
-            return False
+        if self.use_ip_acl() and not ip_acl:
+           LOG.warning('Got LightOS volume without IP ACL?! data: %s', data)
+           return False
 
         ip_acl = ip_acl.get('values')
-        if not ip_acl:
+        if self.use_ip_acl() and not ip_acl:
             LOG.warning(
                 'Got LightOS volume without IP ACL values?! data: %s', data)
             return False
@@ -1172,7 +1189,7 @@ class LightOSVolumeDriver(driver.VolumeDriver):
                 ip_acl.remove(ip)
             except ValueError:
                 LOG.warning(
-                'Could not find matching ip %s in ip-acl %s of LightOS volume',
+                'Could not find matching ip %s in ip-acl of volume  %s ',
                 ip,
                 lightos_volname
                 )
@@ -1183,7 +1200,8 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         return self.set_volume_acl(
             project_name,
             lightos_uuid,
-            acl,ip_acl,
+            acl,
+            ip_acl,
             etag=data.get(
                 'ETag',
                 ''))
@@ -1192,7 +1210,8 @@ class LightOSVolumeDriver(driver.VolumeDriver):
             self,
             project_name,
             lightos_volname,
-            acl,host_ips):
+            acl,
+            host_ips):
         status, data = self._get_lightos_volume(project_name,
                                                 self.logical_op_timeout,
                                                 vol_name=lightos_volname)
@@ -1211,12 +1230,13 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         return self.set_volume_acl(
             project_name,
             lightos_uuid,
-            acl,host_ips,
+            acl,
+            host_ips,
             etag=data.get(
                 'ETag',
                 ''))
 
-    def remove_volume_acl(self, project_name, volume, acl_to_remove,host_ips):
+    def remove_volume_acl(self, project_name, volume, acl_to_remove, host_ips):
         lightos_volname = self._lightos_volname(volume)
         LOG.debug('remove_volume_acl volume %s project %s acl %s',
                   volume, project_name, acl_to_remove)
@@ -1224,7 +1244,8 @@ class LightOSVolumeDriver(driver.VolumeDriver):
             self.__remove_volume_acl,
             project_name,
             lightos_volname,
-            acl_to_remove,host_ips)
+            acl_to_remove,
+            host_ips)
 
     def remove_all_volume_acls(self, project_name, volume):
         lightos_volname = self._lightos_volname(volume)
@@ -1234,9 +1255,10 @@ class LightOSVolumeDriver(driver.VolumeDriver):
             self.__overwrite_volume_acl,
             project_name,
             lightos_volname,
-            ['ALLOW_NONE'],['ALLOW_NONE'])
+            ['ALLOW_NONE'],
+            ['ALLOW_NONE'])
 
-    def update_volume_acl(self, func, project_name, lightos_volname, acl,host_ips):
+    def update_volume_acl(self, func, project_name, lightos_volname, acl, host_ips):
         # loop because lightos api is async
         end = time.time() + self.logical_op_timeout
         first_iteration = True
@@ -1244,7 +1266,7 @@ class LightOSVolumeDriver(driver.VolumeDriver):
             if not first_iteration:
                 time.sleep(1)
             first_iteration = False
-            res = func(project_name, lightos_volname, acl,host_ips)
+            res = func(project_name, lightos_volname, acl, host_ips)
             if not isinstance(res, tuple):
                 LOG.debug('Update_volume: func %s(%s project %s) failed',
                           func, lightos_volname, project_name)
@@ -1452,8 +1474,8 @@ class LightOSVolumeDriver(driver.VolumeDriver):
     def initialize_connection(self, volume, connector):
         hostnqn = connector.get('nqn')
         found_dsc = connector.get('found_dsc')
-        host_ips = connector.get('host_ips',[])
-        LOG.info('Host current IP(s) are ',host_ips)
+        host_ips = connector.get('host_ips',[]) 
+        LOG.info('Current host hostNQN is %s and IP(s) are %s', hostnqn, host_ips)
         LOG.debug(
             'initialize_connection: connector hostnqn is %s found_dsc %s',
             hostnqn,
@@ -1469,13 +1491,13 @@ class LightOSVolumeDriver(driver.VolumeDriver):
             raise exception.VolumeBackendAPIException(message=_(msg))
         
         if not host_ips:
-            msg = ('Connector (%s) did not find host IPs '
-                   'client, aborting' % (connector))
+            msg = 'Connector (%s) did not find host IPs, aborting' % (
+                connector)
             raise exception.VolumeBackendAPIException(message=_(msg))
         
         lightos_volname = self._lightos_volname(volume)
         project_name = self._get_lightos_project_name(volume)
-        success = self.add_volume_acl(project_name, volume, hostnqn,host_ips)
+        success = self.add_volume_acl(project_name, volume, hostnqn, host_ips)
         if not success or not self._wait_for_volume_acl(
                 project_name, lightos_volname, hostnqn, True):
             msg = ('Could not add ACL for hostnqn %s LightOS volume'
@@ -1488,7 +1510,7 @@ class LightOSVolumeDriver(driver.VolumeDriver):
     def terminate_connection(self, volume, connector, **kwargs):
         force = 'force' in kwargs
         hostnqn = connector.get('nqn') if connector else None
-        host_ips = connector.get('host_ips',[]) 
+        host_ips = connector.get('host_ips',[]) if connector else [] 
         LOG.debug(
             'terminate_connection: force %s kwargs %s hostnqn %s',
             force,
@@ -1512,7 +1534,7 @@ class LightOSVolumeDriver(driver.VolumeDriver):
 
         lightos_volname = self._lightos_volname(volume)
         project_name = self._get_lightos_project_name(volume)
-        success = self.remove_volume_acl(project_name, volume, hostnqn,host_ips)
+        success = self.remove_volume_acl(project_name, volume, hostnqn, host_ips)
         if not success or not self._wait_for_volume_acl(
                 project_name, lightos_volname, hostnqn, False):
             LOG.warning(


### PR DESCRIPTION
This change enables cinder-driver to accept a list of the host IPs from connector properties,  and write this list to volume IP/ACL to restrict access.

-  Accept host IPs  form connector properties. 
-  Remove existing value (ALLOW_ANY)  from the given volume's IpAcl
-  Add IP addresses of the host to volume's IP-ACL upon connecting volume to a virtual machine.
- Remove IP addresses of the host from volume's IP-ACL upon disconnecting volume from a virtual machine.