### PR TITLE
Create multiple snapshots from a volume

### DIFF
--- a/cinder/volume/drivers/lightos.py
+++ b/cinder/volume/drivers/lightos.py
@@ -1368,7 +1368,8 @@ class LightOSVolumeDriver(driver.VolumeDriver):
                 )
 
                 if status_code_create in (httpstatus.BAD_REQUEST,
-                       httpstatus.INTERNAL_SERVER_ERROR):
+                       httpstatus.INTERNAL_SERVER_ERROR, 
+                       httpstatus.SERVICE_UNAVAILABLE):
                     
                     LOG.debug('Creating new snapshot %s under project %s' 
                               ' failed, received error with http-status %s',

--- a/cinder/volume/drivers/lightos.py
+++ b/cinder/volume/drivers/lightos.py
@@ -1354,7 +1354,10 @@ class LightOSVolumeDriver(driver.VolumeDriver):
             project_name, self.logical_op_timeout,
             snapshot_name=snapshot_name)
         if status_code_get != httpstatus.OK:
-            end = time.time() + self.logical_op_timeout
+            # These additional 20 seconds will increase request timeout
+            # and avoid failures when multiple clients are requesting large
+            # number of snapshots from same source volume.  
+            end = time.time() + self.logical_op_timeout + 20
             while (time.time() < end):
                 (status_code_create, response) = self.cluster.send_cmd(
                     cmd='create_snapshot',
@@ -1364,8 +1367,12 @@ class LightOSVolumeDriver(driver.VolumeDriver):
                     src_volume_name=src_volume_name,
                 )
 
-                if status_code_create == httpstatus.INTERNAL_SERVER_ERROR:
-                    pass
+                if status_code_create in (httpstatus.BAD_REQUEST,
+                       httpstatus.INTERNAL_SERVER_ERROR):
+                    
+                    LOG.debug('Creating new snapshot %s under project %s' 
+                              ' failed, received error with http-status %s',
+                               snapshot_name, project_name, status_code_create)
                 else:
                     break
 


### PR DESCRIPTION
Lightbits api-service  throws HTTP error when a request for new-snapshot is received while source_volume is busy with an in-progress snapshot. Lightbits version 3.6.1 and older version throw HTTP 400 and version 3.7.1 and newer will throw 500 for snapshot failure. 

This change will enable cinder code to  wait until request timeout or http response status-code changes from 400/500 to other.
This PR adds an additional 20 seconds timeout for  worst case scenario, a large number of snapshots such as 600-700 from a single source of volume at the same time. 

https://lightbitslabs.atlassian.net/browse/LBM1-30941