### PR TITLE
IpAcl disable - bug double ["ALLOW_ANY", "ALLOW_ANY"]

### DIFF
--- a/cinder/volume/drivers/lightos.py
+++ b/cinder/volume/drivers/lightos.py
@@ -1098,7 +1098,7 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         if self.use_ip_acl():
             ip_acl = list(set(ip_acl).union(set(host_ips)))
         else:
-           ip_acl.append('ALLOW_ANY')
+           ip_acl = ['ALLOW_ANY']
 
         # The max (16) elemenets are allowed in IPACL.
         # if elements are more than 16 then remove 


### PR DESCRIPTION
If IpAcl is disable when we update the volume we want to send in the IpAcl ["ALLOW_ANY"].
Currently by mistake we send IpAcl=["ALLOW_ANY","ALLOW_ANY"] lightos fails requests with double values - when fail the request the attach volume fails.
here we set the IpAcl to ["ALLOW_ANY"]

Issue:LBM1-32959