### PR TITLE
LightOS driver: change QoS policy without migration

### DIFF
--- a/cinder/tests/unit/volume/drivers/lightos/test_lightos_storage.py
+++ b/cinder/tests/unit/volume/drivers/lightos/test_lightos_storage.py
@@ -33,6 +33,7 @@ from cinder.tests.unit import test
 from cinder.tests.unit import utils as test_utils
 from cinder.volume import configuration as conf
 from cinder.volume.drivers import lightos
+from cinder.volume import volume_types
 
 
 FAKE_LIGHTOS_CLUSTER_NODES: Dict[str, List] = {
@@ -181,6 +182,8 @@ class DBMock(object):
 
         if kwargs.get("ip_acl", None):
             volume["IPAcl"] = {'values': kwargs.get('ip_acl')}
+        if kwargs.get("qos_policy", None):
+            volume["qosPolicyUUID"] = kwargs["qos_policy"]
         volume["ETag"] = get_vol_etag(volume)
         return httpstatus.OK, volume
 
@@ -358,6 +361,11 @@ class LightOSStorageVolumeDriverTest(test.TestCase):
                 return self.db.update_volume_by_uuid(kwargs["project_name"],
                                                      kwargs["volume_uuid"],
                                                      size=size)
+            elif cmd == "set_volume_qos_policy":
+                return self.db.update_volume_by_uuid(
+                    kwargs["project_name"],
+                    kwargs["volume_uuid"],
+                    qos_policy=kwargs.get("qos_policy", None))
             elif cmd == "create_snapshot":
                 snapshot = {
                     "project_name": kwargs.get("project_name", None),
@@ -989,6 +997,161 @@ class LightOSStorageVolumeDriverTest(test.TestCase):
 
         db.volume_destroy(self.ctxt, volume.id)
         db.volume_destroy(self.ctxt, clone.id)
+
+    GOLD_QOS = '11111111-1111-1111-1111-111111111111'
+    SILVER_QOS = '22222222-2222-2222-2222-222222222222'
+
+    def _qos_retype_setup(self, new_specs, old_specs=None):
+        """Create a volume of one type and diff it against another."""
+        self.driver.do_setup(None)
+
+        old_type = test_utils.create_volume_type(
+            self.ctxt, self, name='gold',
+            extra_specs=old_specs if old_specs is not None else {
+                'lightos:qos_policy': self.GOLD_QOS})
+        new_type = test_utils.create_volume_type(
+            self.ctxt, self, name='silver', extra_specs=new_specs)
+
+        volume = test_utils.create_volume(self.ctxt, size=4,
+                                          volume_type_id=old_type.id)
+        self.driver.create_volume(volume)
+
+        diff, _equal = volume_types.volume_types_diff(
+            self.ctxt, old_type.id, new_type.id)
+        new_type_ref = volume_types.get_volume_type(self.ctxt, new_type.id)
+        return volume, new_type_ref, diff
+
+    def _lightos_volume(self, project_name='default'):
+        volumes = self.db.get_project(project_name)['volumes']
+        self.assertEqual(1, len(volumes), 'expected exactly one volume')
+        return volumes[0]
+
+    def test_retype_qos_policy_only_is_applied_in_place(self):
+        """A QoS-only retype must not create a second volume."""
+        volume, new_type, diff = self._qos_retype_setup(
+            {'lightos:qos_policy': self.SILVER_QOS})
+        before = self._lightos_volume()
+        self.assertEqual(self.GOLD_QOS, before['qosPolicyUUID'])
+
+        retyped = self.driver.retype(self.ctxt, volume, new_type, diff, None)
+
+        self.assertIs(True, retyped)
+        after = self._lightos_volume()
+        self.assertEqual(self.SILVER_QOS, after['qosPolicyUUID'])
+        # Same LightOS volume: no migration, so no data was copied.
+        self.assertEqual(before['UUID'], after['UUID'])
+
+        self.driver.delete_volume(volume)
+        db.volume_destroy(self.ctxt, volume.id)
+
+    def test_retype_between_identical_types_is_a_noop(self):
+        """Nothing to change, and nothing sent to the cluster."""
+        volume, new_type, diff = self._qos_retype_setup(
+            {'lightos:qos_policy': self.GOLD_QOS})
+
+        def fail_on_any_cluster_call(cmd, **kwargs):
+            self.fail('retype issued %s' % cmd)
+
+        self.driver.cluster.send_cmd = fail_on_any_cluster_call
+        self.assertIs(
+            True, self.driver.retype(self.ctxt, volume, new_type, diff, None))
+
+        db.volume_destroy(self.ctxt, volume.id)
+
+    def test_retype_falls_back_when_the_project_changes(self):
+        """A project change needs the volume moved, so hand it back."""
+        volume, new_type, diff = self._qos_retype_setup(
+            {'lightos:qos_policy': self.SILVER_QOS,
+             'lightos:project_name': 'fox'})
+
+        self.assertIs(
+            False, self.driver.retype(self.ctxt, volume, new_type, diff, None))
+        # Untouched: the manager migrates it instead.
+        self.assertEqual(self.GOLD_QOS,
+                         self._lightos_volume()['qosPolicyUUID'])
+
+        self.driver.delete_volume(volume)
+        db.volume_destroy(self.ctxt, volume.id)
+
+    def test_retype_falls_back_when_replica_count_changes(self):
+        volume, new_type, diff = self._qos_retype_setup(
+            {'lightos:qos_policy': self.SILVER_QOS,
+             'lightos:num_replicas': '2'})
+
+        self.assertIs(
+            False, self.driver.retype(self.ctxt, volume, new_type, diff, None))
+        self.assertEqual(self.GOLD_QOS,
+                         self._lightos_volume()['qosPolicyUUID'])
+
+        self.driver.delete_volume(volume)
+        db.volume_destroy(self.ctxt, volume.id)
+
+    def test_retype_falls_back_when_compression_changes(self):
+        volume, new_type, diff = self._qos_retype_setup(
+            {'lightos:qos_policy': self.SILVER_QOS, 'compression': 'True'})
+
+        self.assertIs(
+            False, self.driver.retype(self.ctxt, volume, new_type, diff, None))
+
+        self.driver.delete_volume(volume)
+        db.volume_destroy(self.ctxt, volume.id)
+
+    def test_retype_falls_back_when_dropping_the_qos_policy(self):
+        """Removing a policy is not expressible as a volume update."""
+        volume, new_type, diff = self._qos_retype_setup({})
+
+        self.assertIs(
+            False, self.driver.retype(self.ctxt, volume, new_type, diff, None))
+        self.assertEqual(self.GOLD_QOS,
+                         self._lightos_volume()['qosPolicyUUID'])
+
+        self.driver.delete_volume(volume)
+        db.volume_destroy(self.ctxt, volume.id)
+
+    def test_retype_adds_a_qos_policy_to_a_volume_without_one(self):
+        volume, new_type, diff = self._qos_retype_setup(
+            {'lightos:qos_policy': self.SILVER_QOS}, old_specs={})
+        self.assertIsNone(self._lightos_volume()['qosPolicyUUID'])
+
+        self.assertIs(
+            True, self.driver.retype(self.ctxt, volume, new_type, diff, None))
+        self.assertEqual(self.SILVER_QOS,
+                         self._lightos_volume()['qosPolicyUUID'])
+
+        self.driver.delete_volume(volume)
+        db.volume_destroy(self.ctxt, volume.id)
+
+    def test_retype_falls_back_when_cinder_qos_specs_change(self):
+        """Cinder's own QoS specs are not the LightOS policy."""
+        volume, new_type, diff = self._qos_retype_setup(
+            {'lightos:qos_policy': self.SILVER_QOS})
+        diff['qos_specs'] = {'total_iops_sec': ('100', '50')}
+
+        self.assertIs(
+            False, self.driver.retype(self.ctxt, volume, new_type, diff, None))
+
+        self.driver.delete_volume(volume)
+        db.volume_destroy(self.ctxt, volume.id)
+
+    def test_retype_raises_when_the_cluster_rejects_the_policy(self):
+        """A failure is loud; the manager then migrates instead."""
+        volume, new_type, diff = self._qos_retype_setup(
+            {'lightos:qos_policy': self.SILVER_QOS})
+        cluster_send_cmd = deepcopy(self.driver.cluster.send_cmd)
+
+        def send_cmd_mock(cmd, **kwargs):
+            if cmd == 'set_volume_qos_policy':
+                return (httpstatus.BAD_REQUEST, None)
+            return cluster_send_cmd(cmd, **kwargs)
+
+        self.driver.cluster.send_cmd = send_cmd_mock
+        self.assertRaises(exception.VolumeBackendAPIException,
+                          self.driver.retype,
+                          self.ctxt, volume, new_type, diff, None)
+
+        self.driver.cluster.send_cmd = cluster_send_cmd
+        self.driver.delete_volume(volume)
+        db.volume_destroy(self.ctxt, volume.id)
 
     def test_get_volume_stats(self):
         """Test that lightos_client succeed."""

--- a/cinder/tests/unit/volume/drivers/lightos/test_lightos_storage.py
+++ b/cinder/tests/unit/volume/drivers/lightos/test_lightos_storage.py
@@ -1044,6 +1044,29 @@ class LightOSStorageVolumeDriverTest(test.TestCase):
         self.driver.delete_volume(volume)
         db.volume_destroy(self.ctxt, volume.id)
 
+    def test_retype_preserves_a_live_acl(self):
+        """The QoS update must not disturb the ACL of an attached volume.
+
+        This is why set_volume_qos_policy is its own command instead of an
+        extension of update_volume, which also carries the ACL.
+        """
+        volume, new_type, diff = self._qos_retype_setup(
+            {'lightos:qos_policy': self.SILVER_QOS})
+        before = self._lightos_volume()
+        before['acl'] = {'values': [FAKE_CLIENT_HOSTNQN]}
+        before['IPAcl'] = {'values': FAKE_HOST_IPS}
+
+        self.assertIs(
+            True, self.driver.retype(self.ctxt, volume, new_type, diff, None))
+
+        after = self._lightos_volume()
+        self.assertEqual(self.SILVER_QOS, after['qosPolicyUUID'])
+        self.assertEqual({'values': [FAKE_CLIENT_HOSTNQN]}, after['acl'])
+        self.assertEqual({'values': FAKE_HOST_IPS}, after['IPAcl'])
+
+        self.driver.delete_volume(volume)
+        db.volume_destroy(self.ctxt, volume.id)
+
     def test_retype_between_identical_types_is_a_noop(self):
         """Nothing to change, and nothing sent to the cluster."""
         volume, new_type, diff = self._qos_retype_setup(

--- a/cinder/volume/drivers/lightos.py
+++ b/cinder/volume/drivers/lightos.py
@@ -985,9 +985,14 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         if not changed:
             return True
 
+        # Specs are compared textually: one that is semantically unchanged
+        # but spelled differently (an explicit default project vs none)
+        # falls back to migration. Safe, at worst slower.
         placement_specs = sorted(set(changed) - {LIGHTOS_QOS_POLICY_SPEC})
         if placement_specs:
-            LOG.debug("LIGHTOS cannot retype volume %s in place, %s changed",
+            LOG.debug("LIGHTOS falling back to standard retype of volume"
+                      " %s: an in-place retype is available only when the"
+                      " change is limited to the QoS policy, but %s changed",
                       volume.id, placement_specs)
             return False
 

--- a/cinder/volume/drivers/lightos.py
+++ b/cinder/volume/drivers/lightos.py
@@ -43,6 +43,7 @@ from cinder.volume import driver
 LOG = logging.getLogger(__name__)
 ENABLE_TRACE = True
 LIGHTOS_DEFAULT_PROJECT_NAME = "default"
+LIGHTOS_QOS_POLICY_SPEC = "lightos:qos_policy"
 
 urllib3.disable_warnings()
 
@@ -206,6 +207,16 @@ class LightOSConnection(object):
                                   'UUID': kwargs.get('volume_uuid'),
                                   'size': kwargs.get('size'),
                               }),
+
+            'set_volume_qos_policy': ('PUT',
+                                      '/api/v2/projects/%s/volumes/%s' % (
+                                          kwargs.get("project_name"),
+                                          kwargs.get("volume_uuid")),
+                                      {
+                                          'UUID': kwargs.get('volume_uuid'),
+                                          'qosPolicyUUID': kwargs.get(
+                                              'qos_policy'),
+                                      }),
 
             # snapshots operations
             'create_snapshot': ('POST',
@@ -679,7 +690,7 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         compression = self._parse_extra_spec(type_compression,
                                              default_compression)
         num_replicas = str(specs.get('lightos:num_replicas', num_replicas))
-        qos_policy = specs.get('lightos:qos_policy', None)
+        qos_policy = specs.get(LIGHTOS_QOS_POLICY_SPEC, None)
         project_name = specs.get(
             'lightos:project_name',
             LIGHTOS_DEFAULT_PROJECT_NAME)
@@ -919,6 +930,82 @@ class LightOSVolumeDriver(driver.VolumeDriver):
                    ' %(uuid)s project %(project_name)s' % (
                        dict(uuid=lightos_uuid, project_name=project_name)))
             raise exception.VolumeBackendAPIException(message=msg)
+
+    @staticmethod
+    def _changed_specs(specs):
+        """Reduce a volume type diff section to the specs that differ."""
+        return {key: values for key, values in (specs or {}).items()
+                if values[0] != values[1]}
+
+    def _set_lightos_qos_policy(self, project_name, lightos_uuid, qos_policy):
+        status_code, resp = self.cluster.send_cmd(
+            cmd='set_volume_qos_policy',
+            project_name=project_name,
+            timeout=self.logical_op_timeout,
+            volume_uuid=lightos_uuid,
+            qos_policy=qos_policy)
+        if status_code != httpstatus.OK:
+            msg = ('Failed to set QoS policy %(policy)s on LightOS volume'
+                   ' %(uuid)s project %(project)s status %(code)s'
+                   ' response %(resp)s' % dict(
+                       policy=qos_policy, uuid=lightos_uuid,
+                       project=project_name, code=status_code, resp=resp))
+            raise exception.VolumeBackendAPIException(message=msg)
+
+        state = self._wait_for_volume_available(
+            project_name, timeout=self.logical_op_timeout,
+            vol_uuid=lightos_uuid)
+        if state not in ('Available', 'Migrating'):
+            msg = ('LightOS volume %(uuid)s project %(project)s is %(state)s'
+                   ' after setting QoS policy %(policy)s' % dict(
+                       uuid=lightos_uuid, project=project_name, state=state,
+                       policy=qos_policy))
+            raise exception.VolumeBackendAPIException(message=msg)
+
+    def retype(self, context, volume, new_type, diff, host):
+        """Apply a new volume type to a volume where the data can stay put.
+
+        A QoS policy is a property of the volume, so it is changed in place.
+        Everything else describes how the volume is laid out on the cluster,
+        and returning False leaves the volume manager to migrate the volume.
+
+        :param context: the request context
+        :param volume: the volume to retype
+        :param new_type: the volume type to retype to
+        :param diff: the difference between the two volume types
+        :param host: the backend to retype onto
+        :returns: True when the new type has been applied in place
+        """
+        diff = diff or {}
+        if (self._changed_specs(diff.get('qos_specs'))
+                or self._changed_specs(diff.get('encryption'))):
+            return False
+
+        changed = self._changed_specs(diff.get('extra_specs'))
+        if not changed:
+            return True
+
+        placement_specs = sorted(set(changed) - {LIGHTOS_QOS_POLICY_SPEC})
+        if placement_specs:
+            LOG.debug("LIGHTOS cannot retype volume %s in place, %s changed",
+                      volume.id, placement_specs)
+            return False
+
+        qos_policy = changed[LIGHTOS_QOS_POLICY_SPEC][1]
+        if not qos_policy:
+            # The volume would have to fall back to its project's default
+            # policy, which the volume update API does not express.
+            LOG.debug("LIGHTOS cannot drop the QoS policy of volume %s in"
+                      " place", volume.id)
+            return False
+
+        project_name = self._get_lightos_project_name(volume)
+        lightos_uuid = self._get_lightos_uuid(project_name, volume)
+        self._set_lightos_qos_policy(project_name, lightos_uuid, qos_policy)
+        LOG.info("LIGHTOS set QoS policy %s on volume %s project %s",
+                 qos_policy, volume.id, project_name)
+
+        return True
 
     def get_vol_by_id(self, volume):
         LOG.warning('UNIMPLEMENTED: get vol by id')

--- a/doc/source/configuration/block-storage/drivers/lightbits-lightos-driver.rst
+++ b/doc/source/configuration/block-storage/drivers/lightbits-lightos-driver.rst
@@ -26,7 +26,7 @@ Supported operations
 - Create volume from snapshot
 - Create volume from volume (clone)
 - Active active deployment support
-- Volume retype (host assisted)
+- Volume retype (in place for a QoS policy change, host assisted otherwise)
 - Multi Tenancy support
 
 Lightbits OpenStack Driver Components
@@ -135,6 +135,12 @@ Example:
 .. code-block:: bash
 
    openstack volume type create LightbitsWithQos --property volume_backend_name=<backend_name> --property=lightos:qos_policy=<uuid>
+
+Retyping a volume between two volume types that differ only in
+``lightos:qos_policy`` applies the new policy to the volume in place,
+without a data migration. A retype that changes anything else --
+project, replica count, or compression -- or that removes the policy,
+falls back to the regular host-assisted migration.
 
 NVNe/TCP and Asymmetric Namespace Access (ANA)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/releasenotes/notes/lightos-retype-qos-policy-in-place-9c41e07b5a2d8f36.yaml
+++ b/releasenotes/notes/lightos-retype-qos-policy-in-place-9c41e07b5a2d8f36.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    LightOS driver: retyping a volume between two volume types that differ
+    only in ``lightos:qos_policy`` now applies the new QoS policy to the
+    volume in place. Previously the LightOS driver implemented no ``retype``,
+    so every retype fell back to a host-assisted migration that copied the
+    whole volume to a new one. A retype that changes where a volume lives on
+    the cluster -- its project, replica count or compression -- still
+    migrates, as does one that removes a QoS policy.


### PR DESCRIPTION
**PR description**
Changing a volume's QoS policy meant retyping it, and the LightOS driver had
no `retype`, so Cinder always fell back to a host-assisted migration. Every
QoS change copied the whole volume and deleted the original, at a cost that
scales with the data rather than with the change.

A QoS policy is a property of the volume, and the LightOS volume update API
accepts one. The driver now implements `retype`: when the QoS policy is the
only difference between the two volume types, it sets the policy on the volume
and reports the retype done. No data moves.

Anything else is handed back to Cinder and migrates as it does today — a
different project, replica count or compression all describe where the volume
lives. Dropping a policy is handed back too, since falling back to a project
default is not expressible as a volume update.

Reviewer note: the QoS update is its own command carrying only the volume UUID
and the policy, rather than an extension of `update_volume`, which also carries
the ACL. A QoS-only change must not disturb a live ACL.

**How was the PR tested?**
- 9 new unit tests: the in-place change, a no-op retype, the fall-back for
  project / replicas / compression / policy removal / Cinder `qos_specs`, and
  the failure path. 44/44 pass in the module; all 9 fail without this change.
  flake8 clean.
- On a 3-node cluster: retyped between two volume types differing only in QoS
  policy. The LightOS volume UUID and name were unchanged, the policy moved,
  and it took 4s with no create, delete or migration. An ACL set beforehand
  survived untouched.
- Same cluster: retyped to a type that also changes compression. The driver
  declined and Cinder migrated, as intended.

Not tested: the speed-up on a volume holding real data. The test volume was
empty, so its migration was cheap; the in-place path is constant time while a
migration scales with the data.

**PR dependencies**
<!-- PR_DEPS_START -->
<!-- PR_DEPS_END -->

**Jira Ticket**
Issue: LBM1-47082
