### PR TITLE
LightOS driver: record volume project in provider_id

### DIFF
--- a/cinder/tests/unit/volume/drivers/lightos/test_lightos_storage.py
+++ b/cinder/tests/unit/volume/drivers/lightos/test_lightos_storage.py
@@ -1073,36 +1073,68 @@ class LightOSStorageVolumeDriverTest(test.TestCase):
             name='goose_type')
         volume = test_utils.create_volume(self.ctxt, size=4,
                                           volume_type_id=vol_type.id,
-                                          provider_id='garbage')
+                                          provider_id='one two three')
 
         self.assertEqual('goose',
                          self.driver._get_lightos_project_name(volume))
 
         db.volume_destroy(self.ctxt, volume.id)
 
-    def test_update_provider_info_stamps_volumes_missing_it(self):
-        """Volumes created before we recorded provider_id get stamped."""
+    def test_project_only_provider_id_resolves_the_uuid_by_name(self):
+        """A provider_id carrying only a project still addresses a volume."""
         self.driver.do_setup(None)
 
         src_type, _ = self._project_types()
-        legacy = test_utils.create_volume(self.ctxt, size=4,
+        volume = test_utils.create_volume(self.ctxt, size=4,
                                           volume_type_id=src_type.id)
-        self.driver.create_volume(legacy)
-        gone = test_utils.create_volume(self.ctxt, size=4,
-                                        volume_type_id=src_type.id)
-
-        updates, snap_updates = self.driver.update_provider_info(
-            [legacy, gone], [])
+        self.driver.create_volume(volume)
+        volume.update({'provider_id': 'goose'})
+        volume.save()
 
         lightos_uuid = self.db.get_project('goose')['volumes'][0]['UUID']
-        self.assertEqual([{'id': legacy.id,
-                           'provider_id': 'goose %s' % lightos_uuid}],
-                         updates)
+        self.assertEqual('goose',
+                         self.driver._get_lightos_project_name(volume))
+        self.assertEqual(lightos_uuid,
+                         self.driver._get_lightos_uuid('goose', volume))
+
+        self.driver.delete_volume(volume)
+        self.assertEqual(0, len(self.db.get_project('goose')['volumes']))
+        db.volume_destroy(self.ctxt, volume.id)
+
+    def test_update_provider_info_stamps_without_touching_the_cluster(self):
+        """The backfill must not do IO: it runs before the service is up.
+
+        A deployment can hold tens of thousands of volumes, and this runs
+        before cinder-volume accepts requests.
+        """
+        self.driver.do_setup(None)
+
+        src_type, _ = self._project_types()
+        unstamped = test_utils.create_volume(self.ctxt, size=4,
+                                             volume_type_id=src_type.id)
+        stamped = test_utils.create_volume(
+            self.ctxt, size=4, volume_type_id=src_type.id,
+            provider_id='fox 5eb8d450-98e5-4667-b148-6652ceddcdbf')
+        untyped = test_utils.create_volume(self.ctxt, size=4)
+
+        def fail_on_any_cluster_call(cmd, **kwargs):
+            self.fail('update_provider_info issued %s' % cmd)
+
+        self.driver.cluster.send_cmd = fail_on_any_cluster_call
+        updates, snap_updates = self.driver.update_provider_info(
+            [unstamped, stamped, untyped], [])
+
+        # Already-stamped volumes are left alone, so a restart of a stamped
+        # deployment produces no updates at all.
+        self.assertEqual(
+            [{'id': unstamped.id, 'provider_id': 'goose'},
+             {'id': untyped.id,
+              'provider_id': lightos.LIGHTOS_DEFAULT_PROJECT_NAME}],
+            updates)
         self.assertIsNone(snap_updates)
 
-        self.driver.delete_volume(legacy)
-        db.volume_destroy(self.ctxt, legacy.id)
-        db.volume_destroy(self.ctxt, gone.id)
+        for vol in (unstamped, stamped, untyped):
+            db.volume_destroy(self.ctxt, vol.id)
 
     def test_create_volume_ignores_an_inherited_provider_id(self):
         """The volume type decides where a new volume is created.

--- a/cinder/tests/unit/volume/drivers/lightos/test_lightos_storage.py
+++ b/cinder/tests/unit/volume/drivers/lightos/test_lightos_storage.py
@@ -984,7 +984,16 @@ class LightOSStorageVolumeDriverTest(test.TestCase):
                                          volume_type_id=vol_type.id)
 
         self.driver.create_volume(volume)
-        self.driver.create_cloned_volume(clone, volume)
+        model_update = self.driver.create_cloned_volume(clone, volume)
+
+        # A clone is a creation path: it must record where the clone
+        # lives, like create_volume does.
+        _, lightos_clone = self.db.get_volume_by_name(
+            lightos.LIGHTOS_DEFAULT_PROJECT_NAME, 'volume-%s' % clone.name_id)
+        clone_uuid = lightos_clone['UUID']
+        self.assertEqual({'provider_id': '%s %s' % (
+            lightos.LIGHTOS_DEFAULT_PROJECT_NAME, clone_uuid)}, model_update)
+
         self.driver.delete_volume(volume)
         self.driver.delete_volume(clone)
 
@@ -1115,7 +1124,8 @@ class LightOSStorageVolumeDriverTest(test.TestCase):
         stamped = test_utils.create_volume(
             self.ctxt, size=4, volume_type_id=src_type.id,
             provider_id='fox 5eb8d450-98e5-4667-b148-6652ceddcdbf')
-        untyped = test_utils.create_volume(self.ctxt, size=4)
+        untyped = test_utils.create_volume(self.ctxt, size=4,
+                                           volume_type_id=None)
 
         def fail_on_any_cluster_call(cmd, **kwargs):
             self.fail('update_provider_info issued %s' % cmd)
@@ -1135,6 +1145,24 @@ class LightOSStorageVolumeDriverTest(test.TestCase):
 
         for vol in (unstamped, stamped, untyped):
             db.volume_destroy(self.ctxt, vol.id)
+
+    def test_update_provider_info_leaves_unreadable_types_unstamped(self):
+        """A volume whose type cannot be read must not be stamped by a guess.
+
+        provider_id outranks the volume type, so stamping the default
+        project here would stick even once the type is readable again.
+        """
+        self.driver.do_setup(None)
+
+        # test_utils assigns a volume type that does not exist in the DB,
+        # so reading the type raises.
+        volume = test_utils.create_volume(self.ctxt, size=4)
+
+        updates, _ = self.driver.update_provider_info([volume], [])
+
+        self.assertEqual([], updates)
+
+        db.volume_destroy(self.ctxt, volume.id)
 
     def test_create_volume_ignores_an_inherited_provider_id(self):
         """The volume type decides where a new volume is created.
@@ -1161,17 +1189,14 @@ class LightOSStorageVolumeDriverTest(test.TestCase):
         self.driver.delete_volume(tmp_volume)
         db.volume_destroy(self.ctxt, tmp_volume.id)
 
-    def _retype_across_projects(self, src_type, dst_type, stamp_source=True):
-        """Run a cross-project retype the way the volume manager runs it."""
-        volume = test_utils.create_volume(self.ctxt, size=4,
-                                          volume_type_id=src_type.id)
-        model_update = self.driver.create_volume(volume)
-        if stamp_source:
-            volume.update(model_update)
-            volume.save()
+    def _migrate_across_projects(self, volume, dst_type):
+        """Run the migration hand-over the way the volume manager runs it.
 
-        # Cinder copies the data into a new volume in the destination
-        # project, then hands both records to the driver.
+        Cinder copies the data into a new volume in the destination
+        project, then hands both records to the driver. Returns the
+        throwaway record pointing at the source volume, which Cinder
+        deletes next.
+        """
         new_volume = test_utils.create_volume(self.ctxt, size=4,
                                               volume_type_id=dst_type.id)
         new_volume.update(self.driver.create_volume(new_volume))
@@ -1184,17 +1209,20 @@ class LightOSStorageVolumeDriverTest(test.TestCase):
         volume.refresh()
         new_volume.refresh()
 
-        # Swap the DB records. updated_new is the throwaway record pointing
-        # at the source volume, which Cinder deletes next.
-        updated_new = volume.finish_volume_migration(new_volume)
-        return volume, updated_new
+        # Swap the DB records.
+        return volume.finish_volume_migration(new_volume)
 
     def test_retype_across_projects_deletes_the_source_volume(self):
         """Retyping across projects must not leak the source volume."""
         self.driver.do_setup(None)
         src_type, dst_type = self._project_types()
 
-        volume, updated_new = self._retype_across_projects(src_type, dst_type)
+        volume = test_utils.create_volume(self.ctxt, size=4,
+                                          volume_type_id=src_type.id)
+        volume.update(self.driver.create_volume(volume))
+        volume.save()
+
+        updated_new = self._migrate_across_projects(volume, dst_type)
 
         self.assertEqual(1, len(self.db.get_project('goose')['volumes']))
         self.assertEqual(1, len(self.db.get_project('fox')['volumes']))
@@ -1233,18 +1261,7 @@ class LightOSStorageVolumeDriverTest(test.TestCase):
         volume.update({'provider_id': updates[0]['provider_id']})
         volume.save()
 
-        new_volume = test_utils.create_volume(self.ctxt, size=4,
-                                              volume_type_id=dst_type.id)
-        new_volume.update(self.driver.create_volume(new_volume))
-        new_volume.save()
-
-        fake_manager = mock.Mock()
-        fake_manager.driver = self.driver
-        volume_manager.VolumeManager.update_migrated_volume(
-            fake_manager, self.ctxt, volume, new_volume, 'available')
-        volume.refresh()
-        new_volume.refresh()
-        updated_new = volume.finish_volume_migration(new_volume)
+        updated_new = self._migrate_across_projects(volume, dst_type)
 
         self.driver.delete_volume(updated_new)
 

--- a/cinder/tests/unit/volume/drivers/lightos/test_lightos_storage.py
+++ b/cinder/tests/unit/volume/drivers/lightos/test_lightos_storage.py
@@ -1104,6 +1104,31 @@ class LightOSStorageVolumeDriverTest(test.TestCase):
         db.volume_destroy(self.ctxt, legacy.id)
         db.volume_destroy(self.ctxt, gone.id)
 
+    def test_create_volume_ignores_an_inherited_provider_id(self):
+        """The volume type decides where a new volume is created.
+
+        Cinder copies provider_id onto the temporary volume it creates for a
+        migration, where it still names the source project.
+        """
+        self.driver.do_setup(None)
+        src_type, dst_type = self._project_types()
+
+        tmp_volume = test_utils.create_volume(
+            self.ctxt, size=4, volume_type_id=dst_type.id,
+            provider_id='goose 5eb8d450-98e5-4667-b148-6652ceddcdbf')
+
+        model_update = self.driver.create_volume(tmp_volume)
+
+        self.assertIsNone(self.db.get_project('goose'))
+        lightos_uuid = self.db.get_project('fox')['volumes'][0]['UUID']
+        self.assertEqual({'provider_id': 'fox %s' % lightos_uuid},
+                         model_update)
+
+        tmp_volume.update(model_update)
+        tmp_volume.save()
+        self.driver.delete_volume(tmp_volume)
+        db.volume_destroy(self.ctxt, tmp_volume.id)
+
     def _retype_across_projects(self, src_type, dst_type, stamp_source=True):
         """Run a cross-project retype the way the volume manager runs it."""
         volume = test_utils.create_volume(self.ctxt, size=4,

--- a/cinder/tests/unit/volume/drivers/lightos/test_lightos_storage.py
+++ b/cinder/tests/unit/volume/drivers/lightos/test_lightos_storage.py
@@ -33,6 +33,7 @@ from cinder.tests.unit import test
 from cinder.tests.unit import utils as test_utils
 from cinder.volume import configuration as conf
 from cinder.volume.drivers import lightos
+from cinder.volume import manager as volume_manager
 
 
 FAKE_LIGHTOS_CLUSTER_NODES: Dict[str, List] = {
@@ -989,6 +990,214 @@ class LightOSStorageVolumeDriverTest(test.TestCase):
 
         db.volume_destroy(self.ctxt, volume.id)
         db.volume_destroy(self.ctxt, clone.id)
+
+    def _project_types(self):
+        """A volume type per LightOS project."""
+        src_type = test_utils.create_volume_type(
+            self.ctxt, self,
+            extra_specs={'lightos:project_name': 'goose'},
+            name='goose_type')
+        dst_type = test_utils.create_volume_type(
+            self.ctxt, self,
+            extra_specs={'lightos:project_name': 'fox'},
+            name='fox_type')
+        return src_type, dst_type
+
+    def test_create_volume_records_project_and_uuid(self):
+        """A created volume carries its LightOS address."""
+        self.driver.do_setup(None)
+
+        vol_type = test_utils.create_volume_type(
+            self.ctxt, self,
+            extra_specs={'lightos:project_name': 'goose'},
+            name='goose_type')
+        volume = test_utils.create_volume(self.ctxt, size=4,
+                                          volume_type_id=vol_type.id)
+
+        model_update = self.driver.create_volume(volume)
+
+        lightos_uuid = self.db.get_project('goose')['volumes'][0]['UUID']
+        self.assertEqual({'provider_id': 'goose %s' % lightos_uuid},
+                         model_update)
+
+        self.driver.delete_volume(volume)
+        db.volume_destroy(self.ctxt, volume.id)
+
+    def test_get_lightos_project_name_prefers_provider_id(self):
+        """provider_id wins over a volume type that moved on."""
+        self.driver.do_setup(None)
+
+        vol_type = test_utils.create_volume_type(
+            self.ctxt, self,
+            extra_specs={'lightos:project_name': 'fox'},
+            name='fox_type')
+        volume = test_utils.create_volume(
+            self.ctxt, size=4, volume_type_id=vol_type.id,
+            provider_id='goose 5eb8d450-98e5-4667-b148-6652ceddcdbf')
+
+        self.assertEqual('goose',
+                         self.driver._get_lightos_project_name(volume))
+        self.assertEqual('5eb8d450-98e5-4667-b148-6652ceddcdbf',
+                         self.driver._get_lightos_uuid('goose', volume))
+
+        db.volume_destroy(self.ctxt, volume.id)
+
+    def test_get_lightos_project_name_falls_back_to_volume_type(self):
+        """Volumes with no recorded project still resolve one."""
+        self.driver.do_setup(None)
+
+        vol_type = test_utils.create_volume_type(
+            self.ctxt, self,
+            extra_specs={'lightos:project_name': 'goose'},
+            name='goose_type')
+        legacy = test_utils.create_volume(self.ctxt, size=4,
+                                          volume_type_id=vol_type.id)
+        untyped = test_utils.create_volume(self.ctxt, size=4)
+
+        self.assertIsNone(legacy.provider_id)
+        self.assertEqual('goose',
+                         self.driver._get_lightos_project_name(legacy))
+        self.assertEqual(lightos.LIGHTOS_DEFAULT_PROJECT_NAME,
+                         self.driver._get_lightos_project_name(untyped))
+
+        db.volume_destroy(self.ctxt, legacy.id)
+        db.volume_destroy(self.ctxt, untyped.id)
+
+    def test_get_lightos_project_name_malformed_provider_id(self):
+        """A provider_id we cannot parse must not break the volume."""
+        self.driver.do_setup(None)
+
+        vol_type = test_utils.create_volume_type(
+            self.ctxt, self,
+            extra_specs={'lightos:project_name': 'goose'},
+            name='goose_type')
+        volume = test_utils.create_volume(self.ctxt, size=4,
+                                          volume_type_id=vol_type.id,
+                                          provider_id='garbage')
+
+        self.assertEqual('goose',
+                         self.driver._get_lightos_project_name(volume))
+
+        db.volume_destroy(self.ctxt, volume.id)
+
+    def test_update_provider_info_stamps_volumes_missing_it(self):
+        """Volumes created before we recorded provider_id get stamped."""
+        self.driver.do_setup(None)
+
+        src_type, _ = self._project_types()
+        legacy = test_utils.create_volume(self.ctxt, size=4,
+                                          volume_type_id=src_type.id)
+        self.driver.create_volume(legacy)
+        gone = test_utils.create_volume(self.ctxt, size=4,
+                                        volume_type_id=src_type.id)
+
+        updates, snap_updates = self.driver.update_provider_info(
+            [legacy, gone], [])
+
+        lightos_uuid = self.db.get_project('goose')['volumes'][0]['UUID']
+        self.assertEqual([{'id': legacy.id,
+                           'provider_id': 'goose %s' % lightos_uuid}],
+                         updates)
+        self.assertIsNone(snap_updates)
+
+        self.driver.delete_volume(legacy)
+        db.volume_destroy(self.ctxt, legacy.id)
+        db.volume_destroy(self.ctxt, gone.id)
+
+    def _retype_across_projects(self, src_type, dst_type, stamp_source=True):
+        """Run a cross-project retype the way the volume manager runs it."""
+        volume = test_utils.create_volume(self.ctxt, size=4,
+                                          volume_type_id=src_type.id)
+        model_update = self.driver.create_volume(volume)
+        if stamp_source:
+            volume.update(model_update)
+            volume.save()
+
+        # Cinder copies the data into a new volume in the destination
+        # project, then hands both records to the driver.
+        new_volume = test_utils.create_volume(self.ctxt, size=4,
+                                              volume_type_id=dst_type.id)
+        new_volume.update(self.driver.create_volume(new_volume))
+        new_volume.save()
+
+        fake_manager = mock.Mock()
+        fake_manager.driver = self.driver
+        volume_manager.VolumeManager.update_migrated_volume(
+            fake_manager, self.ctxt, volume, new_volume, 'available')
+        volume.refresh()
+        new_volume.refresh()
+
+        # Swap the DB records. updated_new is the throwaway record pointing
+        # at the source volume, which Cinder deletes next.
+        updated_new = volume.finish_volume_migration(new_volume)
+        return volume, updated_new
+
+    def test_retype_across_projects_deletes_the_source_volume(self):
+        """Retyping across projects must not leak the source volume."""
+        self.driver.do_setup(None)
+        src_type, dst_type = self._project_types()
+
+        volume, updated_new = self._retype_across_projects(src_type, dst_type)
+
+        self.assertEqual(1, len(self.db.get_project('goose')['volumes']))
+        self.assertEqual(1, len(self.db.get_project('fox')['volumes']))
+
+        # The throwaway record points at the goose volume but carries the
+        # fox volume type.
+        self.assertEqual(
+            'fox', self.driver._get_volume_type_project_name(updated_new))
+
+        self.driver.delete_volume(updated_new)
+
+        self.assertEqual(0, len(self.db.get_project('goose')['volumes']),
+                         'the source volume was left behind in goose')
+        self.assertEqual(1, len(self.db.get_project('fox')['volumes']))
+        # The surviving record now addresses the migrated volume in 'fox'.
+        self.assertEqual('fox',
+                         self.driver._get_lightos_project_name(volume))
+
+        self.driver.delete_volume(volume)
+        self.assertEqual(0, len(self.db.get_project('fox')['volumes']))
+
+        db.volume_destroy(self.ctxt, volume.id)
+        db.volume_destroy(self.ctxt, updated_new.id)
+
+    def test_retype_across_projects_after_provider_info_backfill(self):
+        """A volume stamped at service start is not leaked either."""
+        self.driver.do_setup(None)
+        src_type, dst_type = self._project_types()
+
+        # Nothing hands the project over for an unstamped volume, so the
+        # backfill at service start is what makes this safe.
+        volume = test_utils.create_volume(self.ctxt, size=4,
+                                          volume_type_id=src_type.id)
+        self.driver.create_volume(volume)
+        updates = self.driver.update_provider_info([volume], [])[0]
+        volume.update({'provider_id': updates[0]['provider_id']})
+        volume.save()
+
+        new_volume = test_utils.create_volume(self.ctxt, size=4,
+                                              volume_type_id=dst_type.id)
+        new_volume.update(self.driver.create_volume(new_volume))
+        new_volume.save()
+
+        fake_manager = mock.Mock()
+        fake_manager.driver = self.driver
+        volume_manager.VolumeManager.update_migrated_volume(
+            fake_manager, self.ctxt, volume, new_volume, 'available')
+        volume.refresh()
+        new_volume.refresh()
+        updated_new = volume.finish_volume_migration(new_volume)
+
+        self.driver.delete_volume(updated_new)
+
+        self.assertEqual(0, len(self.db.get_project('goose')['volumes']),
+                         'the source volume was left behind in goose')
+        self.assertEqual(1, len(self.db.get_project('fox')['volumes']))
+
+        self.driver.delete_volume(volume)
+        db.volume_destroy(self.ctxt, volume.id)
+        db.volume_destroy(self.ctxt, updated_new.id)
 
     def test_get_volume_stats(self):
         """Test that lightos_client succeed."""

--- a/cinder/volume/drivers/lightos.py
+++ b/cinder/volume/drivers/lightos.py
@@ -615,19 +615,17 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         return None, None
 
     def _get_volume_type_project_name(self, volume):
-        """Return the project requested by the volume type of this volume."""
-        try:
-            extra_specs = volume.volume_type.extra_specs
-            project_name = extra_specs.get(
-                'lightos:project_name',
-                LIGHTOS_DEFAULT_PROJECT_NAME)
-        except Exception:
-            LOG.debug(
-                "LIGHTOS volume %s has no lightos:project_name",
-                volume)
-            project_name = LIGHTOS_DEFAULT_PROJECT_NAME
+        """Return the project requested by the volume type of this volume.
 
-        return project_name
+        An untyped volume resolves to the default project. A volume whose
+        type cannot be read raises: the caller decides whether a guess is
+        acceptable.
+        """
+        if not volume.get('volume_type_id'):
+            return LIGHTOS_DEFAULT_PROJECT_NAME
+
+        return volume.volume_type.extra_specs.get(
+            'lightos:project_name', LIGHTOS_DEFAULT_PROJECT_NAME)
 
     def _get_lightos_project_name(self, volume):
         """Return the LightOS project this volume lives in.
@@ -640,7 +638,14 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         if project_name:
             return project_name
 
-        project_name = self._get_volume_type_project_name(volume)
+        try:
+            project_name = self._get_volume_type_project_name(volume)
+        except Exception:
+            LOG.warning("Could not read the volume type of LIGHTOS volume"
+                        " %s, assuming project %s",
+                        volume['id'], LIGHTOS_DEFAULT_PROJECT_NAME)
+            return LIGHTOS_DEFAULT_PROJECT_NAME
+
         LOG.debug("LIGHTOS volume %s has no project recorded in its"
                   " provider_id, falling back to %s from its volume type",
                   volume['id'], project_name)
@@ -948,8 +953,15 @@ class LightOSVolumeDriver(driver.VolumeDriver):
                     timeout=self. logical_op_timeout,
                     volume_uuid=lightos_uuid))
             # We address the volume by its recorded project and UUID, so a
-            # NOT_FOUND means it is already gone.
-            if status_code in (httpstatus.OK, httpstatus.NOT_FOUND):
+            # NOT_FOUND means it is already gone. Log it: if the address
+            # was wrong, this is the only trace of a volume left behind.
+            if status_code == httpstatus.NOT_FOUND:
+                LOG.warning(
+                    "delete_volume: no LightOS volume with UUID %s in"
+                    " project %s, treating it as already deleted",
+                    lightos_uuid, project_name)
+                break
+            if status_code == httpstatus.OK:
                 break
 
             LOG.warning(

--- a/cinder/volume/drivers/lightos.py
+++ b/cinder/volume/drivers/lightos.py
@@ -440,7 +440,7 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         and setup replication between the newly created volume
         and the secondary volume.
         """
-        project_name = self._get_lightos_project_name(volume)
+        project_name = self._get_volume_type_project_name(volume)
         # Create an intermediate snapshot
         snapshot_name = self._interm_snapshotname(volume)
         src_volume_name = self._lightos_volname(src_vref)
@@ -790,7 +790,11 @@ class LightOSVolumeDriver(driver.VolumeDriver):
 
     def _create_volume(self, volume, src_snapshot_lightos_name):
         lightos_name = self._lightos_volname(volume)
-        project_name = self._get_lightos_project_name(volume)
+        # The volume type says where to create the volume. Do not trust an
+        # inherited provider_id: Cinder copies it onto the temporary volume
+        # it creates for a migration, where it still names the source
+        # project.
+        project_name = self._get_volume_type_project_name(volume)
         lightos_uuid = '<UNKNOWN>'
         vol_state = 'UNKNOWN'
 

--- a/cinder/volume/drivers/lightos.py
+++ b/cinder/volume/drivers/lightos.py
@@ -587,8 +587,15 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         return lightos_volname
 
     @staticmethod
-    def _create_provider_id_string(project_name, lightos_uuid):
-        """Build the provider_id addressing a volume on the cluster."""
+    def _create_provider_id_string(project_name, lightos_uuid=None):
+        """Build the provider_id addressing a volume on the cluster.
+
+        The UUID is optional. A provider_id carrying only a project still
+        addresses the volume, the UUID is then resolved by name.
+        """
+        if not lightos_uuid:
+            return project_name
+
         return "%s %s" % (project_name, lightos_uuid)
 
     @staticmethod
@@ -596,14 +603,16 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         """Return the (project, LightOS UUID) recorded in provider_id."""
         if not provider_id:
             return None, None
-        try:
-            project_name, lightos_uuid = provider_id.split(' ')
-        except (AttributeError, ValueError):
-            LOG.warning("Ignoring malformed LightOS provider_id %s",
-                        provider_id)
-            return None, None
 
-        return project_name, lightos_uuid
+        fields = provider_id.split(' ')
+        if len(fields) == 1:
+            return fields[0], None
+        elif len(fields) == 2:
+            return fields[0], fields[1]
+
+        LOG.warning("Ignoring malformed LightOS provider_id %s", provider_id)
+
+        return None, None
 
     def _get_volume_type_project_name(self, volume):
         """Return the project requested by the volume type of this volume."""
@@ -981,9 +990,10 @@ class LightOSVolumeDriver(driver.VolumeDriver):
     def update_provider_info(self, volumes, snapshots):
         """Stamp provider_id on volumes created before we recorded it.
 
-        Called on service start. Volumes keep working without it through the
-        volume-type fallback, but a retype across projects needs the project
-        recorded to avoid deleting the wrong volume.
+        Runs before the volume service accepts requests, and a deployment can
+        hold tens of thousands of volumes, so this does not talk to the
+        cluster: the project is taken from the volume type. The UUID is left
+        out and resolved by name when something needs it.
 
         :param volumes: List of Cinder volumes to check for updates
         :param snapshots: List of Cinder snapshots to check for updates
@@ -991,22 +1001,20 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         """
         volume_updates = []
         for volume in volumes:
-            if self._parse_provider_id(volume.get('provider_id'))[1]:
+            if self._parse_provider_id(volume.get('provider_id'))[0]:
                 continue
 
-            project_name = self._get_volume_type_project_name(volume)
             try:
-                lightos_uuid = self._lookup_lightos_uuid(project_name, volume)
-            except exception.VolumeNotFound:
-                LOG.warning(
-                    "Not stamping provider_id on volume %s: no LightOS "
-                    "volume found in project %s", volume['id'], project_name)
+                project_name = self._get_volume_type_project_name(volume)
+            except Exception:
+                # Leave the volume unstamped rather than fail to start.
+                LOG.exception("Could not stamp provider_id on volume %s",
+                              volume['id'])
                 continue
 
             volume_updates.append(
                 {'id': volume['id'],
-                 'provider_id': self._create_provider_id_string(
-                     project_name, lightos_uuid)})
+                 'provider_id': self._create_provider_id_string(project_name)})
 
         return volume_updates, None
 

--- a/cinder/volume/drivers/lightos.py
+++ b/cinder/volume/drivers/lightos.py
@@ -457,8 +457,8 @@ class LightOSVolumeDriver(driver.VolumeDriver):
 
         # Create a volume from the intermediate snapshot
         try:
-            self._create_volume(volume,
-                                src_snapshot_lightos_name=snapshot_name)
+            model_update = self._create_volume(
+                volume, src_snapshot_lightos_name=snapshot_name)
         except Exception as e:
             LOG.error("Failed to create volume %s from intermediate "
                       " snapshot %s. Trying to clean up.",
@@ -474,6 +474,8 @@ class LightOSVolumeDriver(driver.VolumeDriver):
                             " volume %s. Trying to clean up.",
                             snapshot_name, src_volume_name)
                 raise e
+
+        return model_update
 
     def create_export(self, context, volume, vg=None):
         """Irrelevant for lightos volumes.
@@ -584,7 +586,27 @@ class LightOSVolumeDriver(driver.VolumeDriver):
         lightos_volname = CONF.volume_name_template % volid
         return lightos_volname
 
-    def _get_lightos_project_name(self, volume):
+    @staticmethod
+    def _create_provider_id_string(project_name, lightos_uuid):
+        """Build the provider_id addressing a volume on the cluster."""
+        return "%s %s" % (project_name, lightos_uuid)
+
+    @staticmethod
+    def _parse_provider_id(provider_id):
+        """Return the (project, LightOS UUID) recorded in provider_id."""
+        if not provider_id:
+            return None, None
+        try:
+            project_name, lightos_uuid = provider_id.split(' ')
+        except (AttributeError, ValueError):
+            LOG.warning("Ignoring malformed LightOS provider_id %s",
+                        provider_id)
+            return None, None
+
+        return project_name, lightos_uuid
+
+    def _get_volume_type_project_name(self, volume):
+        """Return the project requested by the volume type of this volume."""
         try:
             extra_specs = volume.volume_type.extra_specs
             project_name = extra_specs.get(
@@ -595,6 +617,24 @@ class LightOSVolumeDriver(driver.VolumeDriver):
                 "LIGHTOS volume %s has no lightos:project_name",
                 volume)
             project_name = LIGHTOS_DEFAULT_PROJECT_NAME
+
+        return project_name
+
+    def _get_lightos_project_name(self, volume):
+        """Return the LightOS project this volume lives in.
+
+        Recorded in provider_id when the volume is created. The volume type
+        is only a fallback for volumes created before that - it is mutable
+        and goes stale on retype.
+        """
+        project_name, _ = self._parse_provider_id(volume.get('provider_id'))
+        if project_name:
+            return project_name
+
+        project_name = self._get_volume_type_project_name(volume)
+        LOG.debug("LIGHTOS volume %s has no project recorded in its"
+                  " provider_id, falling back to %s from its volume type",
+                  volume['id'], project_name)
 
         return project_name
 
@@ -708,6 +748,14 @@ class LightOSVolumeDriver(driver.VolumeDriver):
             qos_policy=qos_policy)
 
     def _get_lightos_uuid(self, project_name, volume):
+        """Return the LightOS UUID of a volume, by name if not recorded."""
+        _, lightos_uuid = self._parse_provider_id(volume.get('provider_id'))
+        if lightos_uuid:
+            return lightos_uuid
+
+        return self._lookup_lightos_uuid(project_name, volume)
+
+    def _lookup_lightos_uuid(self, project_name, volume):
         lightos_name = self._lightos_volname(volume)
         timeout = self.logical_op_timeout
 
@@ -777,7 +825,11 @@ class LightOSVolumeDriver(driver.VolumeDriver):
                     lightos_name,
                     lightos_uuid,
                     project_name)
-                return
+                # Record where the volume lives, so later operations do not
+                # have to derive the project from the volume type or look the
+                # UUID up by name.
+                return {'provider_id': self._create_provider_id_string(
+                    project_name, lightos_uuid)}
 
             # if volume was created in failed state we should clean it up
             LOG.warning(
@@ -882,7 +934,9 @@ class LightOSVolumeDriver(driver.VolumeDriver):
                     project_name=project_name,
                     timeout=self. logical_op_timeout,
                     volume_uuid=lightos_uuid))
-            if status_code == httpstatus.OK:
+            # We address the volume by its recorded project and UUID, so a
+            # NOT_FOUND means it is already gone.
+            if status_code in (httpstatus.OK, httpstatus.NOT_FOUND):
                 break
 
             LOG.warning(
@@ -919,6 +973,38 @@ class LightOSVolumeDriver(driver.VolumeDriver):
                    ' %(uuid)s project %(project_name)s' % (
                        dict(uuid=lightos_uuid, project_name=project_name)))
             raise exception.VolumeBackendAPIException(message=msg)
+
+    def update_provider_info(self, volumes, snapshots):
+        """Stamp provider_id on volumes created before we recorded it.
+
+        Called on service start. Volumes keep working without it through the
+        volume-type fallback, but a retype across projects needs the project
+        recorded to avoid deleting the wrong volume.
+
+        :param volumes: List of Cinder volumes to check for updates
+        :param snapshots: List of Cinder snapshots to check for updates
+        :returns: tuple (volume_updates, snapshot_updates)
+        """
+        volume_updates = []
+        for volume in volumes:
+            if self._parse_provider_id(volume.get('provider_id'))[1]:
+                continue
+
+            project_name = self._get_volume_type_project_name(volume)
+            try:
+                lightos_uuid = self._lookup_lightos_uuid(project_name, volume)
+            except exception.VolumeNotFound:
+                LOG.warning(
+                    "Not stamping provider_id on volume %s: no LightOS "
+                    "volume found in project %s", volume['id'], project_name)
+                continue
+
+            volume_updates.append(
+                {'id': volume['id'],
+                 'provider_id': self._create_provider_id_string(
+                     project_name, lightos_uuid)})
+
+        return volume_updates, None
 
     def get_vol_by_id(self, volume):
         LOG.warning('UNIMPLEMENTED: get vol by id')

--- a/releasenotes/notes/lightos-fix-retype-orphaned-volume-6ba3f4b1c8de7a25.yaml
+++ b/releasenotes/notes/lightos-fix-retype-orphaned-volume-6ba3f4b1c8de7a25.yaml
@@ -1,0 +1,15 @@
+---
+fixes:
+  - |
+    LightOS driver `bug #44442
+    <https://lightbitslabs.atlassian.net/browse/LBM1-44442>`_: retyping a
+    volume between two volume types that name different LightOS projects
+    left the source volume behind on the backend. The driver resolved a
+    volume's project from the ``lightos:project_name`` extra spec of its
+    volume type on every call, but Cinder keeps the destination volume type
+    on the database record it uses to delete the source volume, so the
+    delete was addressed to the destination project and failed. A volume's
+    project and LightOS UUID are now recorded in its ``provider_id`` when it
+    is created, and travel with the record that addresses it. Volumes created
+    before this fix are stamped automatically when the volume service starts;
+    until then they keep resolving their project from their volume type.

--- a/releasenotes/notes/lightos-fix-retype-orphaned-volume-6ba3f4b1c8de7a25.yaml
+++ b/releasenotes/notes/lightos-fix-retype-orphaned-volume-6ba3f4b1c8de7a25.yaml
@@ -1,8 +1,7 @@
 ---
 fixes:
   - |
-    LightOS driver `bug #44442
-    <https://lightbitslabs.atlassian.net/browse/LBM1-44442>`_: retyping a
+    LightOS driver: retyping a
     volume between two volume types that name different LightOS projects
     left the source volume behind on the backend. The driver resolved a
     volume's project from the ``lightos:project_name`` extra spec of its


### PR DESCRIPTION
**PR description**
Retyping a volume between two volume types that name different LightOS projects
left the source volume behind on the storage. It vanished from OpenStack's view
but kept consuming capacity, leaving only a permission-denied or not-found error
in the cinder-volume log.

A LightOS volume is addressed by its project, and the driver read that project
from the volume type on every call. A volume type is mutable. When a retype
needs the volume moved, Cinder deletes the source through a record that
deliberately keeps the *destination* volume type — a volume type is "not a key
for volume deletion" per `Volume.finish_volume_migration`. So the driver asked
the destination project to delete a volume living in the source project.

A volume's project and LightOS UUID are now recorded in its `provider_id` at
creation, and travel with whichever record addresses that volume, because
Cinder swaps `provider_id` between the two records during the hand-over. The
volume type stays as a fallback, so no data migration is needed.

Three commits: record the project and resolve from it; create volumes in the
project their volume *type* names (Cinder copies `provider_id` onto the
temporary migration volume, where it still names the source project); and stamp
pre-existing volumes at service start. That backfill runs before the service
accepts requests, so it takes the project from the volume type and makes no
cluster calls — `provider_id` accepts a project on its own, and the UUID is
resolved by name when needed.

**How was the PR tested?**
- 9 new unit tests. Two drive a cross-project retype through the real
  `VolumeManager.update_migrated_volume` and `finish_volume_migration` and
  assert the source volume is gone. Others cover resolution, the volume-type
  fallback, an unparseable `provider_id`, creation ignoring an inherited one,
  and the backfill — that test fails on any cluster call, so "no IO" is
  asserted rather than assumed. 44/44 pass; 5 fail without this change.
  flake8 clean.
- On a 3-node cluster with a volume type per project: retyped across projects.
  The source project kept only its untouched volume, the destination held the
  migrated one, and the delete went to the *source* project. Before this change
  it went to the destination and returned 404.
- Backfill at scale: 100 volumes created by the old driver, then restarted on
  this branch. All stamped, no volume lookups, 940ms. A per-volume-lookup
  approach took 6.8s for the same 100, which extrapolates to ~10 min at 10,000.
  Three restarts of 100 already-stamped volumes took ~280ms each.

Not tested: the cross-project retype ran on commit 2 of 3, which the backfill
change does not touch. Test volumes were empty, so no migration copied real
data.

**PR dependencies**
<!-- PR_DEPS_START -->
<!-- PR_DEPS_END -->

**Jira Ticket**
Issue: LBM1-44442
