### PR TITLE
lightos driver: stop global urllib3 warning suppression

### DIFF
--- a/cinder/volume/drivers/lightos.py
+++ b/cinder/volume/drivers/lightos.py
@@ -28,7 +28,6 @@ from oslo_utils import importutils
 from oslo_utils import netutils
 from oslo_utils import units
 import requests
-import urllib3
 
 from cinder.common import constants
 from cinder import coordination
@@ -43,8 +42,6 @@ from cinder.volume import driver
 LOG = logging.getLogger(__name__)
 ENABLE_TRACE = True
 LIGHTOS_DEFAULT_PROJECT_NAME = "default"
-
-urllib3.disable_warnings()
 
 lightos_opts = [
     cfg.ListOpt('lightos_api_address',

--- a/releasenotes/notes/lightos-no-global-ssl-warning-suppression-8e4c1a9f3b2d7c05.yaml
+++ b/releasenotes/notes/lightos-no-global-ssl-warning-suppression-8e4c1a9f3b2d7c05.yaml
@@ -1,0 +1,24 @@
+---
+upgrade:
+  - |
+    Lightbits driver: the driver no longer calls
+    ``urllib3.disable_warnings()`` when its module is imported. That call
+    suppressed **all** urllib3 warnings for the entire ``cinder-volume``
+    process, affecting every configured backend and not just Lightbits, and it
+    took effect even in deployments with no Lightbits backend configured.
+
+    Deployments that run the Lightbits driver with
+    ``driver_ssl_cert_verify = False`` will now see
+    ``InsecureRequestWarning`` messages that were previously hidden. To
+    suppress them, set the existing ``suppress_requests_ssl_warnings`` option,
+    which is the supported, operator-controlled way to do this. The
+    recommended alternative is to enable ``driver_ssl_cert_verify`` and
+    configure a trusted CA bundle.
+security:
+  - |
+    Lightbits driver: an import-scope ``urllib3.disable_warnings()`` call was
+    removed. Because it ran at import time with no warning category argument,
+    it silently disabled every urllib3 warning process-wide -- including TLS
+    warnings raised by other backends sharing the same ``cinder-volume``
+    process -- and overrode the operator's ``suppress_requests_ssl_warnings``
+    setting.


### PR DESCRIPTION
**PR description**
The driver called `urllib3.disable_warnings()` at import scope. With no warning
category argument it suppressed every urllib3 warning for the whole
cinder-volume process, so a TLS warning raised by any other backend sharing that
process was silently dropped. Running at import time it also took effect in
deployments that have no Lightbits backend configured, and it overrode the
operator's choice of `suppress_requests_ssl_warnings`.

This removes the call and the `urllib3` import it was the only user of.
Operators who want these warnings suppressed can set
`suppress_requests_ssl_warnings`, which cinder-volume already applies
process-wide for exactly this purpose (`cinder/volume/manager.py:305`).

Deployments running with `driver_ssl_cert_verify = False` will see
`InsecureRequestWarning` again. The release note covers this and points at both
that option and the better fix of enabling certificate verification.

**How was the PR tested?**
Verified on a live 3-node cluster (kolla, Lightbits 3.21.1), by patching the
driver in place and restarting cinder-volume:

- Driver imports and initializes with the import removed — container healthy,
  no tracebacks or import errors.
- Behaviour measured against a baseline: `InsecureRequestWarning` count was 0
  before the change and 2 after, so the change restores the warning rather than
  being a silent no-op.
- Frequency: the warning is **not** deduplicated — it scales with driver
  activity. Measured on an idle backend and then across real operations:

  | phase | count | delta |
  |---|---|---|
  | idle, after restart | 2 | — |
  | 3 × volume create | 12 | +10 |
  | 3 × VM create (no driver calls) | 12 | 0 |
  | 3 × attach | 30 | +18 |
  | 90 s idle | 30 | 0 |

  That is roughly 3 warnings per volume create and 6 per attach, with no drift
  while idle, and all of them naming the same API endpoint — so the usual
  per-message dedup does not apply here. An operator doing bulk volume work on
  a backend with `driver_ssl_cert_verify = False` should expect a proportional
  number of log lines, and set `suppress_requests_ssl_warnings` if that is
  unwanted. The release note calls this out.
- Not verified: that `suppress_requests_ssl_warnings = True` suppresses this
  warning in practice. `cinder/volume/manager.py:305-309` disables
  `InsecureRequestWarning` explicitly and runs before the driver is
  instantiated, so it is correct by construction — but it was not measured.

No unit test is added: the change removes a module-level side effect and adds no
branch or function to cover, and asserting on global warning-filter state would
test the interpreter rather than the driver.

**PR dependencies**
<!-- PR_DEPS_START -->
<!-- PR_DEPS_END -->

**Jira Ticket**
Issue: LBM1-47383
